### PR TITLE
import path code.google.com/p/gcfg will stop working

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"code.google.com/p/gcfg"
+	"gopkg.in/gcfg.v1"
 )
 
 func checkErr(err error) {


### PR DESCRIPTION
Project migrated to gopkg.in/gcfg.v1
See https://code.google.com/p/gcfg

I got some errors with the deprecated package: imports code.google.com/p/gcfg: Get https://code.google.com/p/gcfg/source/checkout?repo=: x509: certificate signed by unknown authority
